### PR TITLE
better way to set coast mode when disabled

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -19,12 +19,12 @@ public class Robot extends TimedRobot {
   @Override
   public void robotInit() {
     m_robotContainer = new RobotContainer();
+    m_robotContainer.setEnabledNeutralMode();
   }
 
   @Override
   public void robotPeriodic() {
     CommandScheduler.getInstance().run(); 
-    
     m_robotContainer.updatePoseEst();
   }
 
@@ -40,19 +40,18 @@ public class Robot extends TimedRobot {
   public void disabledPeriodic() {
     // if DISABLED_COAST_DELAY seconds have passed since disabling, set the neutral mode to coast
     if (m_neutralModeTimer.get() > RobotConstants.DISABLED_COAST_DELAY) {
-      m_robotContainer.setDisabledNeutralMode();
+      m_robotContainer.startCoastMode();;
       m_neutralModeTimer.stop();
       m_neutralModeTimer.reset();
     }
   }
 
   @Override
-  public void disabledExit() {
-    m_robotContainer.setEnabledNeutralMode();
-  }
+  public void disabledExit() {}
 
   @Override
   public void autonomousInit() {
+    CommandScheduler.getInstance().cancelAll();
     m_autonomousCommand = m_robotContainer.getAutonomousCommand();
 
     if (m_autonomousCommand != null) {
@@ -68,6 +67,7 @@ public class Robot extends TimedRobot {
 
   @Override
   public void teleopInit() {
+    CommandScheduler.getInstance().cancelAll();
     if (m_autonomousCommand != null) {
       m_autonomousCommand.cancel();
     }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -444,6 +444,13 @@ public class RobotContainer {
     CommandScheduler.getInstance().schedule(drivetrain.getCommandFromRequest(() -> drive.withVelocityX(0).withVelocityY(0).withRotationalRate(0)));
   }
 
+  public void startCoastMode() {
+    CommandScheduler.getInstance().schedule(m_elevator.setCoastCommand());
+    CommandScheduler.getInstance().schedule(m_arm.setCoastCommand());
+    CommandScheduler.getInstance().schedule(m_climber.setCoastCommand());
+    CommandScheduler.getInstance().schedule(drivetrain.setCoastCommand());
+  }
+
   public Command getAutonomousCommand() {
     return m_autoChooser.getSelected();
   }

--- a/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -7,6 +7,7 @@ import java.util.function.Supplier;
 import com.ctre.phoenix6.SignalLogger;
 import com.ctre.phoenix6.StatusCode;
 import com.ctre.phoenix6.Utils;
+import com.ctre.phoenix6.controls.CoastOut;
 import com.ctre.phoenix6.hardware.CANcoder;
 import com.ctre.phoenix6.hardware.Pigeon2;
 import com.ctre.phoenix6.signals.NeutralModeValue;
@@ -290,6 +291,15 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
 
     public void setisAutoAlign(boolean isAligned){
         m_isAutoAlign = isAligned;
+    }
+
+    public Command setCoastCommand() {
+        return run(() -> {
+            for (var module : getModules()) {
+                module.getSteerMotor().setControl(new CoastOut());
+                module.getDriveMotor().setControl(new CoastOut());
+            }
+        });
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/climber/ClimberIOHardware.java
+++ b/src/main/java/frc/robot/subsystems/climber/ClimberIOHardware.java
@@ -5,6 +5,7 @@ import static edu.wpi.first.units.Units.RevolutionsPerSecond;
 
 import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
+import com.ctre.phoenix6.controls.CoastOut;
 import com.ctre.phoenix6.controls.PositionVoltage;
 import com.ctre.phoenix6.controls.VoltageOut;
 import com.ctre.phoenix6.hardware.TalonFX;
@@ -70,5 +71,9 @@ public class ClimberIOHardware {
 
     public void setBrake(boolean brake) {
         m_climberMotor.setNeutralMode(brake ? NeutralModeValue.Brake : NeutralModeValue.Coast);
+    }
+
+    public void setCoast() {
+        m_climberMotor.setControl(new CoastOut());
     }
 }

--- a/src/main/java/frc/robot/subsystems/climber/ClimberSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/climber/ClimberSubsystem.java
@@ -38,4 +38,8 @@ public class ClimberSubsystem extends SubsystemBase {
         m_IO.setBrake(false);
     }
 
+    public Command setCoastCommand() {
+        return run(() -> m_IO.setCoast()).ignoringDisable(true);
+    }
+
 }

--- a/src/main/java/frc/robot/subsystems/collar/CollarIOHardware.java
+++ b/src/main/java/frc/robot/subsystems/collar/CollarIOHardware.java
@@ -10,6 +10,7 @@ import com.ctre.phoenix6.hardware.TalonFX;
 
 import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
+import com.ctre.phoenix6.controls.CoastOut;
 import com.ctre.phoenix6.controls.PositionVoltage;
 import com.ctre.phoenix6.controls.VoltageOut;
 
@@ -66,5 +67,9 @@ public class CollarIOHardware {
     
     public void requestClosedLoopPosition(double value) {
         m_collarMotor.setControl(new PositionVoltage(value));
+    }
+
+    public void setCoast() {
+        m_collarMotor.setControl(new CoastOut());
     }
 }

--- a/src/main/java/frc/robot/subsystems/collar/CollarSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/collar/CollarSubsystem.java
@@ -50,8 +50,10 @@ public class CollarSubsystem extends SubsystemBase {
         SmartDashboard.putData("collar/subsystem", this);
         SmartDashboard.putNumber("collar/current", m_IO.getCurrent());
         SmartDashboard.putNumber("collar/velocity", m_IO.getVelocity());
+    }
 
-
+    public Command setCoastCommand() {
+        return run(() -> m_IO.setCoast()).ignoringDisable(true);
     }
  }
 

--- a/src/main/java/frc/robot/subsystems/lifter/ArmIOHardware.java
+++ b/src/main/java/frc/robot/subsystems/lifter/ArmIOHardware.java
@@ -13,6 +13,7 @@ import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.controls.ControlRequest;
+import com.ctre.phoenix6.controls.CoastOut;
 import com.ctre.phoenix6.controls.PositionVoltage;
 import com.ctre.phoenix6.controls.VoltageOut;
 
@@ -130,4 +131,7 @@ public class ArmIOHardware {
 
         m_armMotor.getConfigurator().apply(talonFXConfigs);
     }
+    public void setCoast() {
+        m_armMotor.setControl(new CoastOut());
+    } 
 }

--- a/src/main/java/frc/robot/subsystems/lifter/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/lifter/ArmSubsystem.java
@@ -270,4 +270,8 @@ public class ArmSubsystem extends SubsystemBase {
     public void setRunKeepInPlace(boolean bool) {
         runKeepInPlacePID = bool;
     }
+
+    public Command setCoastCommand() {
+        return run(() -> m_IO.setCoast()).ignoringDisable(true);
+    }
 }

--- a/src/main/java/frc/robot/subsystems/lifter/ElevatorIOHardware.java
+++ b/src/main/java/frc/robot/subsystems/lifter/ElevatorIOHardware.java
@@ -14,6 +14,7 @@ import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.controls.ControlRequest;
+import com.ctre.phoenix6.controls.CoastOut;
 import com.ctre.phoenix6.controls.PositionVoltage;
 import com.ctre.phoenix6.controls.VoltageOut;
 
@@ -129,4 +130,7 @@ public class ElevatorIOHardware {
         m_elevatorMotor.getConfigurator().apply(talonFXConfigs);
     }
 
+    public void setCoast() {
+        m_elevatorMotor.setControl(new CoastOut());
+    }
 }

--- a/src/main/java/frc/robot/subsystems/lifter/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/lifter/ElevatorSubsystem.java
@@ -266,4 +266,8 @@ public class ElevatorSubsystem extends SubsystemBase{
     public boolean isTall() {
         return m_IO.getPosition() > ElevatorConstants.MIN_HEIGHT_TO_BE_TALL;
     }
+
+    public Command setCoastCommand() {
+        return run(() -> m_IO.setCoast()).ignoringDisable(true);
+    }
 }


### PR DESCRIPTION
Old way could possibly be causing autonomous to delay significantly (0.5) seconds at the start.

Using set control api (which is hopefully non-blocking) to work around this issue.